### PR TITLE
解决修改了后台路径后编辑按钮链接错误的问题

### DIFF
--- a/components/post-list.php
+++ b/components/post-list.php
@@ -1,4 +1,7 @@
-<?php $color = color($this->options->color); ?>
+<?php
+$color = color($this->options->color);
+$rounded = $this->options->rounded == 'rightAngle'?'rounded-0':'';  //  获取元素风格设置
+?>
 
 <?php while ($this->next()):  //  开始循环  ?>
     <div class="post <?php echo $rounded; ?>">

--- a/components/post-list.php
+++ b/components/post-list.php
@@ -53,7 +53,7 @@
             </div>
             <a href="<?php $this->permalink() ?>" target="<?php $this->options->listLinkOpen(); ?>" class="float-right d-sm-none d-none d-md-inline d-lg-inline d-xl-inline <?php echo $color['link']; ?>">阅读全文</a>
             <?php if ($this->user->hasLogin()): ?>
-                <a href="<?php echo $this->options->siteUrl . 'admin/write-post.php?cid=' . $this->cid; ?>" class="float-right mr-3 d-sm-none d-none d-md-inline d-lg-inline d-xl-inline <?php echo $color['link']; ?>">编辑</a>
+                <a href="<?php $this->options->adminUrl('write-post.php?cid=' . $this->cid); ?>" class="float-right mr-3 d-sm-none d-none d-md-inline d-lg-inline d-xl-inline <?php echo $color['link']; ?>">编辑</a>
             <?php endif; ?>
         </div>
     </div>

--- a/post.php
+++ b/post.php
@@ -84,7 +84,7 @@ $this->need('components/header.php');
                     <?php if ($this->user->hasLogin()): ?>
                         <div class="info d-sm-none d-none d-md-inline d-lg-inline d-xl-inline">
                             <i class="icon icon-pencil <?php echo $color['link']; ?>"></i>
-                            <a class="<?php echo $color['link']; ?>" href="<?php echo $this->options->siteUrl . 'admin/write-post.php?cid=' . $this->cid; ?>" >编辑</a>
+                            <a class="<?php echo $color['link']; ?>" href="<?php $this->options->adminUrl('write-post.php?cid=' . $this->cid); ?>" >编辑</a>
                         </div>
                     <?php endif; ?>
                 </div>


### PR DESCRIPTION
之前编辑按钮直接写入 /admin/ 路径，但是如果更改了后台入口的话就失效了。

改为使用 adminUrl 以避免这个问题。